### PR TITLE
feat(core): add bootstrap scripts for renaming project

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,27 @@
+param (
+    [string]$NewName
+)
+
+if (-not $NewName) {
+    Write-Host "Usage: .\bootstrap.ps1 <NewName> (e.g. .\bootstrap.ps1 MyNewProject) Note: The new name must not contain whitespace."
+    exit 1
+}
+
+# Ensure no whitespace in the new name.
+if ($NewName -match "\s") {
+    Write-Host "Error: The new name must not contain whitespace."
+    exit 1
+}
+
+# Rename occurrences in file contents.
+Get-ChildItem -Recurse -File | Where-Object { $_.Name -notmatch "package.json|bootstrap.ps1|bootstrap.sh" } | ForEach-Object {
+    (Get-Content $_.FullName) -replace "Template", $NewName | Set-Content $_.FullName
+}
+
+# Rename files and directories.
+Get-ChildItem -Recurse -Depth 10 -Name "*Template*" | ForEach-Object {
+    $newName = $_ -replace "Template", $NewName
+    Rename-Item -Path $_ -NewName $newName
+}
+
+Write-Host "Renaming complete!"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <NewName> (e.g. $0 MyNewProject) Note: The new name must not contain whitespace."
+    exit 1
+fi
+
+NEW_NAME="$1"
+
+# Validate that the new name contains no whitespace.
+if [[ "$NEW_NAME" =~ \  ]]; then
+    echo "Error: The new name must not contain whitespace."
+    exit 1
+fi
+
+# Rename occurrences in file contents, excluding the .git directory and the package.json file.
+grep -rl 'Template' . --exclude-dir=.git --exclude="package.json" --exclude="bootstrap.sh" --exclude="bootstrap.ps1" | while read -r file; do
+    sed -i "s/Template/$NEW_NAME/g" "$file"
+done
+
+# Rename files and directories.
+find . -depth -name '*Template*' | while read -r file; do
+    newfile=$(echo "$file" | sed "s/Template/$NEW_NAME/g")
+    mv "$file" "$newfile"
+done
+
+echo "Renaming complete!"


### PR DESCRIPTION
This PR adds a shell and a PowerShell script for renaming the project's assemblies and namespaces to avoid having to manually change every instance of the `Template` name.

These don't affect the `package.json` as it has a different naming convention so we KISS and let the user change it themselves rather than asking for multiple inputs or using a best-guess replacement.