### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.1.0] - 2025-02-02
+
+### Added
+
+- Bootstrap scripts to rename assemblies and namespaces
+- `csc.rsp` and files to enable nullable reference types for the project
+
+### Changed
+
+- Removed `PEAK_TESTING` define constraint from test assemblies
+
 ## [v1.0.1] - 2024-12-17
 
 ### Added

--- a/Editor/csc.rsp
+++ b/Editor/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable

--- a/Editor/csc.rsp.meta
+++ b/Editor/csc.rsp.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fc4b587c0f3a4601a869c106961bc26f
+timeCreated: 1735191773

--- a/README.md
+++ b/README.md
@@ -6,15 +6,13 @@ This is a template for creating UPM packages. We use this for developing and mai
 
 1. Use this repository as a template for your new package
 2. Clone the repository to your local machine
-3. Modify the `package.json` file to define your package
-4. Modify the `README.md` and `Documentation/Template.md` files to include your package's info
-5. Modify the assemblies and namespaces to match your org/package name
-   - `Frostpeak.Template` -> `YourOrg.YourPackage`
-   - `Frostpeak.Template.Tests` -> `YourOrg.YourPackage.Tests`
-   - `Frostpeak.Template.Editor` -> `YourOrg.YourPackage.Editor`
-   - `Frostpeak.Template.Editor.Tests` -> `YourOrg.YourPackage.Editor.Tests`
-6. For non Frostpeak Studios packages, remove the `PEAK_TESTING` define constraint from the test assemblies
-7. Develop your package
+3. Run the `bootstrap.sh` (or `bootstrap.ps1` for Windows) script to rename assemblies and namespaces.
+   - This will replace the `Template` name with your package's name
+   - Name must not contain whitespace
+   - These scripts can be deleted after running
+4. Modify the `package.json` file to define your package, **this is not modified by the bootstrap script**
+5. Modify the `README.md` and `Documentation/Template.md` files to include your package's info
+6. Develop your package
 
 ## Development Workflow
 

--- a/Runtime/csc.rsp
+++ b/Runtime/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable

--- a/Runtime/csc.rsp.meta
+++ b/Runtime/csc.rsp.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fc4b587c0f3a4601a869c106961bc26f
+timeCreated: 1735191773

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,27 @@
+param (
+    [string]$NewName
+)
+
+if (-not $NewName) {
+    Write-Host "Usage: .\bootstrap.ps1 <NewName> (e.g. .\bootstrap.ps1 MyNewProject) Note: The new name must not contain whitespace."
+    exit 1
+}
+
+# Ensure no whitespace in the new name.
+if ($NewName -match "\s") {
+    Write-Host "Error: The new name must not contain whitespace."
+    exit 1
+}
+
+# Rename occurrences in file contents.
+Get-ChildItem -Recurse -File | Where-Object { $_.Name -notmatch "package.json|bootstrap.ps1|bootstrap.sh" } | ForEach-Object {
+    (Get-Content $_.FullName) -replace "Template", $NewName | Set-Content $_.FullName
+}
+
+# Rename files and directories.
+Get-ChildItem -Recurse -Depth 10 -Name "*Template*" | ForEach-Object {
+    $newName = $_ -replace "Template", $NewName
+    Rename-Item -Path $_ -NewName $newName
+}
+
+Write-Host "Renaming complete!"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <NewName> (e.g. $0 MyNewProject) Note: The new name must not contain whitespace."
+    exit 1
+fi
+
+NEW_NAME="$1"
+
+# Validate that the new name contains no whitespace.
+if [[ "$NEW_NAME" =~ \  ]]; then
+    echo "Error: The new name must not contain whitespace."
+    exit 1
+fi
+
+# Rename occurrences in file contents, excluding the .git directory and the package.json file.
+grep -rl 'Template' . --exclude-dir=.git --exclude="package.json" --exclude="bootstrap.sh" --exclude="bootstrap.ps1" | while read -r file; do
+    sed -i "s/Template/$NEW_NAME/g" "$file"
+done
+
+# Rename files and directories.
+find . -depth -name '*Template*' | while read -r file; do
+    newfile=$(echo "$file" | sed "s/Template/$NEW_NAME/g")
+    mv "$file" "$newfile"
+done
+
+echo "Renaming complete!"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.frostpeakstudios.upm-template",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "displayName": "Frostpeak Studios UPM Template",
     "description": "Template for Unity UPM packages.",
     "unity": "2021.3",


### PR DESCRIPTION
This version brings some minor updates, most notably bootstrapping scripts to automate changing the assembly/namespace names.

Also removed the test assembly define for `PEAK_TESTING` as we're no longer relying on define symbols internally.